### PR TITLE
Reduce duplicity in Native implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This project establishes a Java based client to interact with a Supabase databas
 Java based library for its database, so I tried to make one instead.
 
 ### Supabase Java Native
-A Supabase client library written in vanilla Java. It contains minimal dependencies to external libraries and makes use of 
-Apache HTTPClient to interact with the Supabase database API. 
+A Supabase client library written in vanilla Java. It contains minimal dependencies to external libraries and makes use of
+Apache HTTPClient to interact with the Supabase database API.
 
 ### Supabase Java Spring
 A Supabase client that is native to the Spring 3 framework. It uses WebClient under
@@ -14,7 +14,28 @@ the hood to interact with the Supabase database API.
 
 ## Quick Start
 
-### Initialization
+### Importing Maven Dependency
+If you want to use the native Java client then include the following dependency in your POM file:
+
+```dtd
+<dependency>
+    <groupId>com.skhanal5</groupId>
+    <artifactId>supabase-java-native</artifactId>
+    <version>1.0-SNAPSHOT</version>
+</dependency>
+```
+
+For the Spring based client, use this dependency instead in your POM file:
+
+```dtd
+<dependency>
+  <groupId>com.skhanal5</groupId>
+  <artifactId>supabase-java-spring</artifactId>
+  <version>1.0-SNAPSHOT</version>
+</dependency>
+```
+
+### Client Initialization
 
 The easiest way of initalizing a SupabaseClient is by passing in the base URL of your Supabase database from your
 dashboard along with the service key.

--- a/supabase-java-native/src/main/java/com/skhanal5/core/SupabaseClient.java
+++ b/supabase-java-native/src/main/java/com/skhanal5/core/SupabaseClient.java
@@ -3,8 +3,6 @@ package com.skhanal5.core;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import com.skhanal5.core.internal.SupabaseHttpRequest;
-import com.skhanal5.core.internal.SupabaseHttpRequestSender;
 import com.skhanal5.models.DeleteQuery;
 import com.skhanal5.models.InsertQuery;
 import com.skhanal5.models.SelectQuery;

--- a/supabase-java-native/src/main/java/com/skhanal5/core/SupabaseHttpRequest.java
+++ b/supabase-java-native/src/main/java/com/skhanal5/core/SupabaseHttpRequest.java
@@ -1,4 +1,4 @@
-package com.skhanal5.core.internal;
+package com.skhanal5.core;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -9,7 +9,7 @@ import java.net.http.HttpRequest;
 import java.util.*;
 import java.util.Map.Entry;
 
-public class SupabaseHttpRequest {
+class SupabaseHttpRequest {
 
     URI uri;
 
@@ -21,11 +21,11 @@ public class SupabaseHttpRequest {
 
     private static final ObjectMapper requestMapper = new ObjectMapper();
 
-    public SupabaseHttpRequest(String baseURI,
+    SupabaseHttpRequest(String baseURI,
                                Map<String,String> defaultHeaders,
                                Query query) {
-        this.uri = buildURI(baseURI, query.getTable(), queryParameters);
         this.queryParameters = query.buildQueryParams().orElse(Map.of());
+        this.uri = buildURI(baseURI, query.getTable(), queryParameters);
         this.requestBody = query.buildRequestBody().orElse(List.of());
         this.headers = mergeHeaders(defaultHeaders, query.buildAdditionalHeaders());
     }
@@ -35,8 +35,7 @@ public class SupabaseHttpRequest {
         headersToAdd.ifPresent(mergedHeaders::putAll);
         return mergedHeaders;
     }
-
-   public  HttpRequest buildRequest(String methodName) throws JsonProcessingException {
+    HttpRequest buildRequest(String methodName) throws JsonProcessingException {
         var requestBuilder = HttpRequest.newBuilder();
         headers.forEach(requestBuilder::setHeader);
         headers.put("Content-Type", "application/json"); //move this inside of the query's buildHeaders method as needed
@@ -52,14 +51,18 @@ public class SupabaseHttpRequest {
         return URI.create(fullURI);
     }
 
-    private static StringJoiner serializeQueryParameters(Map<String, String> queryParameters) {
+    private static String serializeQueryParameters(Map<String, String> queryParameters) {
+        if (queryParameters == null || queryParameters.isEmpty()) {
+            return "";
+        }
+
         StringJoiner stringifyPathParams = new StringJoiner("&");
         for (Entry<String, String> keyValuePair : queryParameters.entrySet()) {
             String currPathParam = keyValuePair.getKey() + "=" + encodeSpaces(keyValuePair.getValue());
             stringifyPathParams
                     .add(currPathParam);
         }
-        return stringifyPathParams;
+        return stringifyPathParams.toString();
     }
 
     private static String encodeSpaces(String URI) {

--- a/supabase-java-native/src/main/java/com/skhanal5/core/SupabaseHttpRequestSender.java
+++ b/supabase-java-native/src/main/java/com/skhanal5/core/SupabaseHttpRequestSender.java
@@ -1,35 +1,29 @@
-package com.skhanal5.core.internal;
+package com.skhanal5.core;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.skhanal5.models.Query;
+import com.skhanal5.core.SupabaseHttpRequest;
 
-import java.net.URI;
 import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 
-import java.util.*;
-import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
 
-public class SupabaseHttpRequestSender {
+class SupabaseHttpRequestSender {
 
     HttpClient client;
 
     ObjectMapper mapper;
 
 
-    public SupabaseHttpRequestSender(HttpClient client,
+    SupabaseHttpRequestSender(HttpClient client,
                                      ObjectMapper mapper) {
         this.client = client;
         this.mapper = mapper;
     }
 
-    public <T> CompletableFuture<T> invokeRequest(String requestMethod, SupabaseHttpRequest request, Class<T> responseType) throws JsonProcessingException {
+    <T> CompletableFuture<T> invokeRequest(String requestMethod, SupabaseHttpRequest request, Class<T> responseType) throws JsonProcessingException {
         var httpRequest = request.buildRequest(requestMethod);
         return client
                 .sendAsync(httpRequest, BodyHandlers.ofString())

--- a/supabase-java-native/src/main/java/com/skhanal5/core/internal/SupabaseHttpRequest.java
+++ b/supabase-java-native/src/main/java/com/skhanal5/core/internal/SupabaseHttpRequest.java
@@ -1,75 +1,69 @@
 package com.skhanal5.core.internal;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.skhanal5.models.Query;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.StringJoiner;
 
 public class SupabaseHttpRequest {
 
-    String baseURI;
+    URI uri;
 
-    String table;
+    Map<String, String> queryParameters;
 
-    Map<String,String > headers;
+    List<Map<String, Object>> requestBody;
 
-    Optional<Map<String, String>> queryParameters;
+    Map<String, String> headers;
 
-    Optional<List<Map<String,Object>>> requestBody;
+    private static final ObjectMapper requestMapper = new ObjectMapper();
 
-    public SupabaseHttpRequest(String baseURI, String table, Map<String, String> headers, Query query) {
-        this.baseURI = baseURI;
-        this.table = table;
-        this.headers = headers;
-        this.queryParameters = query.buildQueryParams();
-        this.requestBody = query.buildRequestBody();
+    public SupabaseHttpRequest(String baseURI,
+                               Map<String,String> defaultHeaders,
+                               Query query) {
+        this.uri = buildURI(baseURI, query.getTable(), queryParameters);
+        this.queryParameters = query.buildQueryParams().orElse(Map.of());
+        this.requestBody = query.buildRequestBody().orElse(List.of());
+        this.headers = mergeHeaders(defaultHeaders, query.buildAdditionalHeaders());
     }
 
-    public HttpRequest toHttpGetRequest() {
+    private Map<String,String> mergeHeaders(Map<String,String> headers, Optional<Map<String,String>> headersToAdd) {
+        var mergedHeaders = new HashMap<>(headers);
+        headersToAdd.ifPresent(mergedHeaders::putAll);
+        return mergedHeaders;
+    }
+
+   public  HttpRequest buildRequest(String methodName) throws JsonProcessingException {
         var requestBuilder = HttpRequest.newBuilder();
-        var uri = buildURI(baseURI, table, queryParameters);
-        headers.forEach((key, value) -> requestBuilder.setHeader(key, value.toString()));
+        headers.forEach(requestBuilder::setHeader);
+        headers.put("Content-Type", "application/json"); //move this inside of the query's buildHeaders method as needed
+        String requestBodyToJsonString = requestMapper.writeValueAsString(requestBody);
         return requestBuilder
                 .uri(uri)
+                .method(methodName,  HttpRequest.BodyPublishers.ofString(requestBodyToJsonString))
                 .build();
     }
 
-    public HttpRequest toHttpPostRequest() {
-        var requestBuilder = HttpRequest.newBuilder();
-        var uri = buildURI(baseURI, table, queryParameters);
-        headers.forEach((key, value) -> requestBuilder.setHeader(key, value.toString()));
-        return requestBuilder
-                .uri(uri)
-                .POST(HttpRequest.BodyPublishers.ofString(requestBody.toString()))
-                .build();
-    }
-
-    private static HttpRequest.Builder addHeaders(HttpRequest.Builder requestBuilder, Map<String, List<String>> headers) {
-        headers.forEach((key, value) -> requestBuilder.setHeader(key, value.toString()));
-        return requestBuilder;
-    }
-
-    public static URI buildURI(String baseURI, String path, Optional<Map<String, String>> queryParameters) {
-        if (queryParameters.isPresent()) {
-            String fullURI = baseURI + "/" + path + "?" + serializeQueryParameters(queryParameters.get());
-            return URI.create(fullURI);
-        }
-        String fullURI = baseURI + "/" + path;
+    private static URI buildURI(String baseURI, String path, Map<String, String> queryParameters) {
+        String fullURI = baseURI + path + "?" + serializeQueryParameters(queryParameters);
         return URI.create(fullURI);
     }
 
     private static StringJoiner serializeQueryParameters(Map<String, String> queryParameters) {
         StringJoiner stringifyPathParams = new StringJoiner("&");
-        for (Entry<String,String> keyValuePair : queryParameters.entrySet()) {
-            String currPathParam = keyValuePair.getKey() + "=" + keyValuePair.getValue();
+        for (Entry<String, String> keyValuePair : queryParameters.entrySet()) {
+            String currPathParam = keyValuePair.getKey() + "=" + encodeSpaces(keyValuePair.getValue());
             stringifyPathParams
                     .add(currPathParam);
         }
         return stringifyPathParams;
     }
+
+    private static String encodeSpaces(String URI) {
+        return URI.replace(" ", "%20");
+    }
+
 }

--- a/supabase-java-native/src/main/java/com/skhanal5/core/internal/SupabaseHttpRequestSender.java
+++ b/supabase-java-native/src/main/java/com/skhanal5/core/internal/SupabaseHttpRequestSender.java
@@ -13,137 +13,34 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 
-public class SupabaseHttpRequestSender<T> {
+public class SupabaseHttpRequestSender {
 
     HttpClient client;
 
-    String table;
-
-    Optional<Map<String,String>> queryParameters;
-
-    Optional<List<Map<String, Object>>> requestBody;
-
-    Map<String, String> headers;
-
     ObjectMapper mapper;
 
-    Class<T> responseType;
 
-    String baseURI;
-
-
-    public SupabaseHttpRequestSender(String baseURI,
-                                     HttpClient client,
-                                     Map<String,String> defaultHeaders,
-                                     Query query,
-                                     Class<T> responseType,
+    public SupabaseHttpRequestSender(HttpClient client,
                                      ObjectMapper mapper) {
-        this.baseURI = baseURI;
         this.client = client;
-        this.table = query.getTable();
-        this.queryParameters = query.buildQueryParams();
-        this.requestBody = query.buildRequestBody();
-        this.headers = mergeHeaders(defaultHeaders, query.buildAdditionalHeaders());
-        this.responseType = responseType;
         this.mapper = mapper;
     }
 
-
-    public CompletableFuture<T> invokeGETRequest() {
-        var request = toGetRequest(baseURI, table, headers, queryParameters.orElse(Map.of()));
+    public <T> CompletableFuture<T> invokeRequest(String requestMethod, SupabaseHttpRequest request, Class<T> responseType) throws JsonProcessingException {
+        var httpRequest = request.buildRequest(requestMethod);
         return client
-                .sendAsync(request, BodyHandlers.ofString())
-                .thenApply(this::deserializeIntoPOJO); //process into responseType
+                .sendAsync(httpRequest, BodyHandlers.ofString())
+                .thenApply(e -> deserializeIntoPOJO(e, responseType));
     }
 
-    public CompletableFuture<T> invokePOSTRequest() {
-        headers.put("Content-Type", "application/json");
-        var request = toPostRequest(baseURI,table, headers, queryParameters.orElse(Map.of()), requestBody.orElse(List.of()));
-        return client
-                .sendAsync(request, BodyHandlers.ofString())
-                .thenApply(this::deserializeIntoPOJO); //process into responseType
-    }
-
-    public CompletableFuture<T> invokePATCHRequest() {
-        headers.put("Content-Type", "application/json");
-        var request = toPatchRequest(baseURI,table, headers, queryParameters.orElse(Map.of()), requestBody.orElse(List.of()));
-        return client
-                .sendAsync(request, BodyHandlers.ofString())
-                .thenApply(this::deserializeIntoPOJO); //process into responseType
-    }
-
-    public CompletableFuture<T> invokeDELETERequest() {
-        var request = toDeleteRequest(baseURI,table, headers, queryParameters.orElse(Map.of()));
-        return client
-                .sendAsync(request, BodyHandlers.ofString())
-                .thenApply(this::deserializeIntoPOJO); //process into responseType
-    }
-
-    private HttpRequest toGetRequest(String baseURI, String table, Map<String, String> headers, Map<String, String> queryParameters) {
-        var requestBuilder = HttpRequest.newBuilder();
-        var uri = buildURI(baseURI, table, queryParameters);
-        headers.forEach(requestBuilder::setHeader);
-        return requestBuilder
-                .uri(uri)
-                .GET()
-                .build();
-    }
-
-    private HttpRequest toPatchRequest(String baseURI, String table, Map<String, String> headers, Map<String, String> queryParameters, List<Map<String,Object>> requestBody) {
-        var requestBuilder = HttpRequest.newBuilder();
-        var uri = buildURI(baseURI, table, queryParameters);
-        headers.forEach(requestBuilder::setHeader);
-        String requestBodyToJsonString = null;
-        try {
-            requestBodyToJsonString = this.mapper.writeValueAsString(requestBody);
-            return requestBuilder
-                    .uri(uri)
-                    .method("PATCH",  HttpRequest.BodyPublishers.ofString(requestBodyToJsonString))
-                    .build();
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-
-
-    private HttpRequest toPostRequest(String baseURI, String table, Map<String, String> headers, Map<String, String> queryParameters, List<Map<String,Object>> requestBody) {
-        var requestBuilder = HttpRequest.newBuilder();
-        var uri = buildURI(baseURI, table, queryParameters);
-        headers.forEach(requestBuilder::setHeader);
-        String requestBodyToJsonString = null;
-        try {
-            requestBodyToJsonString = this.mapper.writeValueAsString(requestBody);
-            return requestBuilder
-                    .uri(uri)
-                    .POST(HttpRequest.BodyPublishers.ofString(requestBodyToJsonString))
-                    .build();
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private HttpRequest toDeleteRequest(String baseURI, String table, Map<String, String> headers, Map<String, String> queryParameters) {
-        var requestBuilder = HttpRequest.newBuilder();
-        var uri = buildURI(baseURI, table, queryParameters);
-        headers.forEach(requestBuilder::setHeader);
-        return requestBuilder
-                .uri(uri)
-                .DELETE()
-                .build();
-    }
-
-    private static URI buildURI(String baseURI, String path, Map<String, String> queryParameters) {
-        String fullURI = baseURI + path + "?" + serializeQueryParameters(queryParameters);
-        return URI.create(fullURI);
-    }
-
-    private T deserializeIntoPOJO(HttpResponse<String> jsonResponse) {
+    private <T> T  deserializeIntoPOJO(HttpResponse<String> jsonResponse, Class<T> responseType) {
         if (jsonResponse.statusCode() >= 200 || jsonResponse.statusCode() < 300) {
             var jsonBody = jsonResponse.body();
 
-            if (jsonBody != null || jsonBody.length() > 1) {
+            if (jsonBody != null && jsonBody.length() > 1) {
                 jsonBody = jsonBody.substring(1,jsonBody.length()-1);
             }
 
@@ -159,25 +56,5 @@ public class SupabaseHttpRequestSender<T> {
         }
         //TODO: Handle other status codes other than 200's
         return null;
-    }
-
-    private Map<String,String> mergeHeaders(Map<String,String> defaultHeaders, Optional<Map<String,String>> additionalHeaders) {
-        var mergedHeaders = new HashMap<>(defaultHeaders);
-        additionalHeaders.ifPresent(mergedHeaders::putAll);
-        return mergedHeaders;
-    }
-
-    private static StringJoiner serializeQueryParameters(Map<String, String> queryParameters) {
-        StringJoiner stringifyPathParams = new StringJoiner("&");
-        for (Entry<String, String> keyValuePair : queryParameters.entrySet()) {
-            String currPathParam = keyValuePair.getKey() + "=" + encodeSpaces(keyValuePair.getValue());
-            stringifyPathParams
-                    .add(currPathParam);
-        }
-        return stringifyPathParams;
-    }
-
-    private static String encodeSpaces(String URI) {
-        return URI.replace(" ", "%20");
     }
 }

--- a/supabase-java-spring/src/main/java/com/skhanal5/core/SupabaseClient.java
+++ b/supabase-java-spring/src/main/java/com/skhanal5/core/SupabaseClient.java
@@ -1,6 +1,5 @@
 package com.skhanal5.core;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.skhanal5.models.DeleteQuery;
 import com.skhanal5.models.InsertQuery;
 import com.skhanal5.models.SelectQuery;
@@ -22,35 +21,24 @@ import java.util.function.Consumer;
  * interact with Supabase Database via REST. Utilizes WebClient and Jackson
  * under the hood to handle sending requests to Supabase Database API and
  * serializing responses.
- *
- * We expose two ways of initializing an instance of SupabaseClient to consumers .
+ * <br>
+ * We expose one way of initializing an instance of SupabaseClient to consumers .
  * @see #newInstance(String, String)    Using the database url and service key
- * @see #newInstance(String, String, ObjectMapper) Using the databaes url, service key, and a Jackson ObjectMapper
  */
 public class SupabaseClient {
 
     @NonNull
     WebClient client;
 
-    @NonNull
-    ObjectMapper mapper;
-
     private static final String ENDPOINT_PATH = "/rest/v1/";
 
     private SupabaseClient(WebClient client) {
         this.client = client;
-        this.mapper = new ObjectMapper();
-    }
-
-    private SupabaseClient(WebClient client, ObjectMapper mapper) {
-       this.client = client;
-       this.mapper = mapper;
     }
 
     /**
      * Executes a SelectQuery and returns the search response as a POJO of type responseType. The responseType
      * class definition should match the schema of your table.
-     *
      * @param query The query to execute
      * @param responseType The class of the POJO that you want the response to be converted to
      * @return  the response POJO
@@ -65,10 +53,10 @@ public class SupabaseClient {
     /**
      * Executes a InsertQuery and returns the inserted row as a POJO of type responseType. The responseType
      * class definition should match the schema of your table.
-     *
+     * <br>
+     * <br>
      * Note: Nothing will be returned, if select() is not explicitly invoked in your InsertQuery. The method
      * will return null.
-     *
      * @param query The query to execute
      * @param responseType The class of the POJO that you want the response to be converted to
      * @return  the response POJO or null
@@ -83,13 +71,13 @@ public class SupabaseClient {
     /**
      * Executes a UpdateQuery and returns the updated row as a POJO of type responseType. The responseType
      * class definition should match the schema of your table.
-     *
+     * <br>
+     * <br>
      * Note: Nothing will be returned, if select() is not explicitly invoked in your UpdateQuery. The method
      * will return null.
-     *
      * @param query The query to execute
      * @param responseType The class of the POJO that you want the response to be converted to
-     * @return  the response POJO or null
+     * @return the response POJO or null
      * @param <T> the type of the expected response POJO
      */
     public <T> T executeUpdate(UpdateQuery query, Class<T> responseType) {
@@ -102,10 +90,10 @@ public class SupabaseClient {
     /**
      * Executes a DeleteQuery and returns the deleted row as a POJO of type responseType. The responseType
      * class definition should match the schema of your table.
-     *
+     * <br>
+     * <br>
      * Note: Nothing will be returned, if select() is not explicitly invoked in your DeleteQuery. The method
      * will return null.
-     *
      * @param query The query to execute
      * @param responseType The class of the POJO that you want the response to be converted to
      * @return  the response POJO or null
@@ -139,13 +127,9 @@ public class SupabaseClient {
                                    Class<T> responseType) {
         return client
                 .post()
-                .uri(uriBuilder -> {
-                    var uri =  uriBuilder
+                .uri(uriBuilder -> uriBuilder
                             .path(table)
-                            .build();
-                    System.out.println(uri);
-                    return uri;
-                })
+                            .build())
                 .contentType(MediaType.APPLICATION_JSON)
                 .headers(headersConsumer)
                 .bodyValue(requestBody)
@@ -161,14 +145,10 @@ public class SupabaseClient {
                                    Class<T> responseType) {
         return client
                 .patch()
-                .uri(uriBuilder -> {
-                    var uri =  uriBuilder
+                .uri(uriBuilder -> uriBuilder
                             .path(table)
                             .queryParams(queryParameters)
-                            .build();
-                    System.out.println(uri);
-                    return uri;
-                })
+                            .build())
                 .contentType(MediaType.APPLICATION_JSON)
                 .headers(headers)
                 .bodyValue(requestBody)
@@ -183,14 +163,10 @@ public class SupabaseClient {
                                     Class<T> responseType) {
         return client
                 .delete()
-                .uri(uriBuilder -> {
-                    var uri =  uriBuilder
+                .uri(uriBuilder -> uriBuilder
                             .path(table)
                             .queryParams(queryParameters)
-                            .build();
-                    System.out.println(uri);
-                    return uri;
-                })
+                            .build())
                 .headers(headers)
                 .retrieve()
                 .bodyToMono(responseType)
@@ -207,7 +183,6 @@ public class SupabaseClient {
         map.ifPresent(mapUnwrapped -> mapUnwrapped.forEach(remapped::add));
         return remapped;
     }
-
 
     /**
      * The most basic way of making an instance of the SupabaseClient. Utilizes built-in object mapper that
@@ -227,27 +202,5 @@ public class SupabaseClient {
                 .build();
 
         return new SupabaseClient(client);
-    }
-
-    /**
-     * An alternative factory method to building a SupabaseClient. Allows consumers to provide their own ObjectMapper
-     * in case there is a use case that requires the responseType POJO in database operations to be deserialized in a
-     * specific manner.
-     *
-     * @param databaseUrl Represents the Supabase Database API base URL.
-     * @param serviceKey Represents the Supabase Database service key. Note, this should not be exposed to clients.
-     * @param mapper An instance of Jackson's ObjectMapper.
-     * @return an instance of a SupabaseClient
-     */
-    public static SupabaseClient newInstance(@NonNull String databaseUrl, @NonNull String serviceKey, @NonNull ObjectMapper mapper) {
-        var baseUrl = databaseUrl + ENDPOINT_PATH;
-        var client = WebClient
-                .builder()
-                .baseUrl(baseUrl)
-                .defaultHeader("apikey", serviceKey)
-                .defaultHeader("Authorization", "Bearer " + serviceKey)
-                .build();
-
-       return new SupabaseClient(client, mapper);
     }
 }

--- a/supabase-java-spring/src/test/java/com/skhanal5/core/SupabaseClientTest.java
+++ b/supabase-java-spring/src/test/java/com/skhanal5/core/SupabaseClientTest.java
@@ -1,6 +1,5 @@
 package com.skhanal5.core;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -22,24 +21,5 @@ public class SupabaseClientTest {
         var key = "";
         var supabaseClient = SupabaseClient.newInstance(url, key);
         Assertions.assertNotNull(supabaseClient.client);
-        Assertions.assertNotNull(supabaseClient.mapper);
-    }
-
-    @Test
-    void testNewInstanceURLKeyAndMapperMinimal() {
-        var url = "";
-        var key = "";
-        Assertions.assertThrows(NullPointerException.class, () -> SupabaseClient.newInstance(url, key, null));
-    }
-
-    @Test
-    void testNewInstanceURLKeyAndMapper() {
-        var url = "";
-        var key = "";
-        var mapper = new ObjectMapper();
-        var supabaseClient = SupabaseClient.newInstance(url,key,mapper);
-        Assertions.assertNotNull(supabaseClient);
-        Assertions.assertNotNull(supabaseClient.client);
-        Assertions.assertEquals(mapper, supabaseClient.mapper);
     }
 }


### PR DESCRIPTION
Native Changes:
- Make use of SupabaseHttpRequest by moving all request related code from SupabaseHTTPRequestSender
- Remove helper request sender methods in SupabaseHTTPRequestSender for each of the CRUD operations
- Remove shared instance variables in SupabaseClient and SupabaseHTTPRequestSender
- Initialize one instance of SupabaseHTTPRequestSender in SupabaseClient

#22 #18 