### PR TITLE
Enhancements: Add more test to Spring client

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To insert a row or multiple rows into the table, you can use the `InsertQuery`.
         .build();
 ```
 
-Note: this method will return null if you do not invoke `select()`. If select is invoked, it will
+Note: Executing this query will return null if you do not invoke `select()`. If select is invoked, it will
 return the new row/rows inserted in the table.
 
 #### UpdateQuery
@@ -100,7 +100,7 @@ filtering, view the [section on using Filters](#Filters).
         .build();
 ```
 
-Note: this method will return null if you do not invoke `select()`. If select is invoked, it will
+Note: Executing this query will return null if you do not invoke `select()`. If select is invoked, it will
 return the updated row in the table.
 
 #### DeleteQuery
@@ -122,7 +122,7 @@ If you want to delete a specific row (or rows), you can use the `DeleteQuery` al
         .build();
 ```
 
-Note: If you do not invoke the `select()` method, you will not get a response back from doing this operation. Invoking it returns the deleted row(s).
+Note: If you do not invoke the `select()` method, you will not get a response back from executing this query. Invoking it returns the deleted row(s).
 
 ### Executing a Query
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Java based library for its database, so I tried to make one instead.
 
 ### Supabase Java Native
 A Supabase client library written in vanilla Java. It contains minimal dependencies to external libraries and makes use of
-Apache HTTPClient to interact with the Supabase database API.
+Java's HttpClient to interact with the Supabase database API.
 
 ### Supabase Java Spring
 A Supabase client that is native to the Spring 3 framework. It uses WebClient under
@@ -37,7 +37,7 @@ For the Spring based client, use this dependency instead in your POM file:
 
 ### Client Initialization
 
-The easiest way of initalizing a SupabaseClient is by passing in the base URL of your Supabase database from your
+The easiest way of initializing a SupabaseClient is passing in the base URL of your Supabase database from your
 dashboard along with the service key.
 
 ```dtd
@@ -77,7 +77,7 @@ To insert a row or multiple rows into the table, you can use the `InsertQuery`.
         .build();
 ```
 
-Note: this method will return an empty string if you do not invoke select(). If select is invoked, it will
+Note: this method will return null if you do not invoke `select()`. If select is invoked, it will
 return the new row/rows inserted in the table.
 
 #### UpdateQuery
@@ -100,7 +100,7 @@ filtering, view the [section on using Filters](#Filters).
         .build();
 ```
 
-Note: this method will return an empty string if you do not invoke select(). If select is invoked, it will
+Note: this method will return null if you do not invoke `select()`. If select is invoked, it will
 return the updated row in the table.
 
 #### DeleteQuery

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
   <properties>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
+    <maven.surefire.plugin.version>3.5.2</maven.surefire.plugin.version>
     <mockito.version>5.12.0</mockito.version>
     <lombok.version>1.18.34</lombok.version>
     <junit-jupiter.version>5.11.0</junit-jupiter.version>
@@ -58,6 +59,11 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven.surefire.plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,28 +33,28 @@
     <spotless.version>2.43.0</spotless.version>
   </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <version>${lombok.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
-      <version>${mockito.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>${junit-jupiter.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <version>${junit-jupiter.version}</version>
-    </dependency>
-  </dependencies>
+    <dependencies>
+      <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>${lombok.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <version>${mockito.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>${junit-jupiter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <version>${junit-jupiter.version}</version>
+      </dependency>
+    </dependencies>
 
   <build>
     <plugins>

--- a/supabase-java-common/src/main/java/com/skhanal5/models/UpdateQuery.java
+++ b/supabase-java-common/src/main/java/com/skhanal5/models/UpdateQuery.java
@@ -61,10 +61,10 @@ public class UpdateQuery implements Query {
     }
 
     /**
-     * Used to specify the values we want to insert into the table.
+     * Used to specify the values we want to update into the table.
      *
      * @param value a list of Map<String,Object> where each Map represents a row that we want to
-     *     insert. The key is the column name and the value is its corresponding value in the type
+     *     update. The key is the column name and the value is its corresponding value in the type
      *     that the column accepts.
      * @return a UpdateQueryBuilder with this configured
      */

--- a/supabase-java-native/src/main/java/com/skhanal5/core/SupabaseClient.java
+++ b/supabase-java-native/src/main/java/com/skhanal5/core/SupabaseClient.java
@@ -46,12 +46,6 @@ public class SupabaseClient {
    * @param <T> the type of the expected response POJO
    */
   public <T> T executeSelect(SelectQuery query, Class<T> responseType) {
-    //    try {
-    //      var request = new SupabaseHttpRequest(baseURI, defaultHeaders, query);
-    //      return sender.invokeRequest("GET", request, responseType).get();
-    //    } catch (JsonProcessingException | InterruptedException | ExecutionException e) {
-    //      throw new RuntimeException(e);
-    //    }
     return this.execute(query, responseType, "GET");
   }
 
@@ -68,12 +62,6 @@ public class SupabaseClient {
    * @param <T> the type of the expected response POJO
    */
   public <T> T executeInsert(InsertQuery query, Class<T> responseType) {
-    //    try {
-    //      var request = new SupabaseHttpRequest(baseURI, defaultHeaders, query);
-    //      return sender.invokeRequest("POST", request, responseType).get();
-    //    } catch (InterruptedException | ExecutionException | JsonProcessingException e) {
-    //      throw new RuntimeException(e);
-    //    }
     return this.execute(query, responseType, "POST");
   }
 
@@ -90,13 +78,6 @@ public class SupabaseClient {
    * @param <T> the type of the expected response POJO
    */
   public <T> T executeUpdate(UpdateQuery query, Class<T> responseType) {
-    //    try {
-    //      var request = new SupabaseHttpRequest(baseURI, defaultHeaders, query);
-    //      return sender.invokeRequest("PATCH", request, responseType).get();
-    //    } catch (InterruptedException | ExecutionException | JsonProcessingException e) {
-    //      throw new RuntimeException(e);
-    //    }
-
     return this.execute(query, responseType, "PATCH");
   }
 
@@ -113,12 +94,6 @@ public class SupabaseClient {
    * @param <T> the type of the expected response POJO
    */
   public <T> T executeDelete(DeleteQuery query, Class<T> responseType) {
-    //    try {
-    //      var request = new SupabaseHttpRequest(baseURI, defaultHeaders, query);
-    //      return sender.invokeRequest("DELETE", request, responseType).get();
-    //    } catch (InterruptedException | ExecutionException | JsonProcessingException e) {
-    //      throw new RuntimeException(e);
-    //    }
     return this.execute(query, responseType, "DELETE");
   }
 

--- a/supabase-java-native/src/main/java/com/skhanal5/core/SupabaseClient.java
+++ b/supabase-java-native/src/main/java/com/skhanal5/core/SupabaseClient.java
@@ -36,7 +36,6 @@ public class SupabaseClient {
     this.defaultHeaders = defaultHeaders;
   }
 
-
   /**
    * Executes a SelectQuery and returns the search response as a POJO of type responseType. The
    * responseType class definition should match the schema of your table.

--- a/supabase-java-native/src/main/java/com/skhanal5/core/SupabaseClient.java
+++ b/supabase-java-native/src/main/java/com/skhanal5/core/SupabaseClient.java
@@ -36,13 +36,6 @@ public class SupabaseClient {
     this.defaultHeaders = defaultHeaders;
   }
 
-  //  private SupabaseClient(
-  //      HttpClient client, String baseURI, Map<String, String> defaultHeaders, ObjectMapper
-  // mapper) {
-  //    this.sender = new SupabaseHttpRequestSender(client, mapper);
-  //    this.baseURI = baseURI;
-  //    this.defaultHeaders = defaultHeaders;
-  //  }
 
   /**
    * Executes a SelectQuery and returns the search response as a POJO of type responseType. The

--- a/supabase-java-spring/pom.xml
+++ b/supabase-java-spring/pom.xml
@@ -63,8 +63,8 @@
         <!-- https://mvnrepository.com/artifact/org.wiremock/wiremock -->
         <dependency>
             <groupId>org.wiremock</groupId>
-            <artifactId>wiremock</artifactId>
-            <version>3.9.1</version>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>3.9.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/supabase-java-spring/pom.xml
+++ b/supabase-java-spring/pom.xml
@@ -11,19 +11,6 @@
 
     <artifactId>supabase-java-spring</artifactId>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <!-- Import dependency management from Spring Boot -->
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.3.0</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
 
         <!-- common dependency -->
@@ -37,29 +24,9 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
+            <version>3.3.5</version>
         </dependency>
 
-        <!-- Testing dependencies -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.jupiter</groupId>
-                    <artifactId>junit-jupiter</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.mockito</groupId>
-                    <artifactId>mockito-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/org.wiremock/wiremock -->
         <dependency>
             <groupId>org.wiremock</groupId>

--- a/supabase-java-spring/pom.xml
+++ b/supabase-java-spring/pom.xml
@@ -60,6 +60,13 @@
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.wiremock/wiremock -->
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>3.9.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/supabase-java-spring/pom.xml
+++ b/supabase-java-spring/pom.xml
@@ -41,14 +41,19 @@
 
         <!-- Testing dependencies -->
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/supabase-java-spring/src/main/java/com/skhanal5/core/SpringSupabaseClient.java
+++ b/supabase-java-spring/src/main/java/com/skhanal5/core/SpringSupabaseClient.java
@@ -23,13 +23,13 @@ import org.springframework.web.reactive.function.client.WebClient;
  *
  * @see #newInstance(String, String) Using the database url and service key
  */
-public class SupabaseClient {
+public class SpringSupabaseClient {
 
   @NonNull WebClient client;
 
   private static final String ENDPOINT_PATH = "/rest/v1/";
 
-  SupabaseClient(WebClient client) {
+  SpringSupabaseClient(WebClient client) {
     this.client = client;
   }
 
@@ -184,7 +184,7 @@ public class SupabaseClient {
    *     exposed to clients.
    * @return an instance of a SupabaseClient
    */
-  public static SupabaseClient newInstance(
+  public static SpringSupabaseClient newInstance(
       @NonNull String databaseUrl, @NonNull String serviceKey) {
     var baseUrl = databaseUrl + ENDPOINT_PATH;
     var client =
@@ -194,6 +194,6 @@ public class SupabaseClient {
             .defaultHeader("Authorization", "Bearer " + serviceKey)
             .build();
 
-    return new SupabaseClient(client);
+    return new SpringSupabaseClient(client);
   }
 }

--- a/supabase-java-spring/src/main/java/com/skhanal5/core/SupabaseClient.java
+++ b/supabase-java-spring/src/main/java/com/skhanal5/core/SupabaseClient.java
@@ -103,7 +103,7 @@ public class SupabaseClient {
     return this.makeDeleteAPICall(query.getTable(), headers, queryParams, responseType);
   }
 
-  <T> T makeSelectAPICall(
+  private <T> T makeSelectAPICall(
       String table,
       MultiValueMap<String, String> queryParameters,
       Consumer<HttpHeaders> headersConsumer,
@@ -117,7 +117,7 @@ public class SupabaseClient {
         .block();
   }
 
-  <T> T makeInsertDBCall(
+  private <T> T makeInsertDBCall(
       String table,
       List<Map<String, Object>> requestBody,
       Consumer<HttpHeaders> headersConsumer,
@@ -133,7 +133,7 @@ public class SupabaseClient {
         .block();
   }
 
-  <T> T makeUpdateDBCall(
+  private <T> T makeUpdateDBCall(
       String table,
       Consumer<HttpHeaders> headers,
       MultiValueMap<String, String> queryParameters,
@@ -150,7 +150,7 @@ public class SupabaseClient {
         .block();
   }
 
-  <T> T makeDeleteAPICall(
+  private <T> T makeDeleteAPICall(
       String table,
       Consumer<HttpHeaders> headers,
       MultiValueMap<String, String> queryParameters,

--- a/supabase-java-spring/src/main/java/com/skhanal5/core/SupabaseClient.java
+++ b/supabase-java-spring/src/main/java/com/skhanal5/core/SupabaseClient.java
@@ -164,8 +164,7 @@ public class SupabaseClient {
         .block();
   }
 
-  Consumer<HttpHeaders> constructHttpHeaders(
-      Optional<Map<String, String>> additionalHeaders) {
+  Consumer<HttpHeaders> constructHttpHeaders(Optional<Map<String, String>> additionalHeaders) {
     MultiValueMap<String, String> headersToMap = toMultiValueMap(additionalHeaders);
     return headers -> headers.addAll(headersToMap);
   }

--- a/supabase-java-spring/src/main/java/com/skhanal5/core/SupabaseClient.java
+++ b/supabase-java-spring/src/main/java/com/skhanal5/core/SupabaseClient.java
@@ -29,7 +29,7 @@ public class SupabaseClient {
 
   private static final String ENDPOINT_PATH = "/rest/v1/";
 
-  private SupabaseClient(WebClient client) {
+  SupabaseClient(WebClient client) {
     this.client = client;
   }
 
@@ -103,7 +103,7 @@ public class SupabaseClient {
     return this.makeDeleteAPICall(query.getTable(), headers, queryParams, responseType);
   }
 
-  private <T> T makeSelectAPICall(
+  <T> T makeSelectAPICall(
       String table,
       MultiValueMap<String, String> queryParameters,
       Consumer<HttpHeaders> headersConsumer,
@@ -117,7 +117,7 @@ public class SupabaseClient {
         .block();
   }
 
-  private <T> T makeInsertDBCall(
+  <T> T makeInsertDBCall(
       String table,
       List<Map<String, Object>> requestBody,
       Consumer<HttpHeaders> headersConsumer,
@@ -133,7 +133,7 @@ public class SupabaseClient {
         .block();
   }
 
-  private <T> T makeUpdateDBCall(
+  <T> T makeUpdateDBCall(
       String table,
       Consumer<HttpHeaders> headers,
       MultiValueMap<String, String> queryParameters,
@@ -150,7 +150,7 @@ public class SupabaseClient {
         .block();
   }
 
-  private <T> T makeDeleteAPICall(
+  <T> T makeDeleteAPICall(
       String table,
       Consumer<HttpHeaders> headers,
       MultiValueMap<String, String> queryParameters,
@@ -164,13 +164,13 @@ public class SupabaseClient {
         .block();
   }
 
-  private Consumer<HttpHeaders> constructHttpHeaders(
+  Consumer<HttpHeaders> constructHttpHeaders(
       Optional<Map<String, String>> additionalHeaders) {
     MultiValueMap<String, String> headersToMap = toMultiValueMap(additionalHeaders);
-    return bulkHeaders -> bulkHeaders.addAll(headersToMap);
+    return headers -> headers.addAll(headersToMap);
   }
 
-  private MultiValueMap<String, String> toMultiValueMap(Optional<Map<String, String>> map) {
+  MultiValueMap<String, String> toMultiValueMap(Optional<Map<String, String>> map) {
     MultiValueMap<String, String> remapped = new LinkedMultiValueMap<>();
     map.ifPresent(mapUnwrapped -> mapUnwrapped.forEach(remapped::add));
     return remapped;

--- a/supabase-java-spring/src/main/resources/application.properties
+++ b/supabase-java-spring/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=supabase-spring

--- a/supabase-java-spring/src/test/java/com/skhanal5/core/ClientIntegrationTest.java
+++ b/supabase-java-spring/src/test/java/com/skhanal5/core/ClientIntegrationTest.java
@@ -1,2 +1,23 @@
-package com.skhanal5.core;public class ClientIntegrationTest {
+package com.skhanal5.core;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+@WireMockTest
+public class ClientIntegrationTest {
+
+    @Test
+    void testExecuteSelect() {
+
+        stubFor(WireMock.get(urlEqualTo("")).willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody("")));
+
+        var client = SupabaseClient.newInstance("http://localhost:8080","");
+
+    }
+
 }

--- a/supabase-java-spring/src/test/java/com/skhanal5/core/ClientIntegrationTest.java
+++ b/supabase-java-spring/src/test/java/com/skhanal5/core/ClientIntegrationTest.java
@@ -2,6 +2,8 @@ package com.skhanal5.core;
 
 import com.skhanal5.core.mockserver.MockServer;
 import com.skhanal5.models.*;
+
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;

--- a/supabase-java-spring/src/test/java/com/skhanal5/core/ClientIntegrationTest.java
+++ b/supabase-java-spring/src/test/java/com/skhanal5/core/ClientIntegrationTest.java
@@ -1,25 +1,71 @@
 package com.skhanal5.core;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.skhanal5.core.mockserver.MockServer;
+import com.skhanal5.models.*;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-@WireMockTest
 public class ClientIntegrationTest {
+
+  private static MockServer mockServer;
+
+  private static String baseUrl = "http://localhost:8080";
+
+  @BeforeAll
+  public static void setupServer() {
+    mockServer = new MockServer();
+    mockServer.registerSupabaseStubs();
+    mockServer.start();
+  }
+
+  @AfterAll
+  public static void stopServer() {
+    mockServer.stop();
+  }
 
   @Test
   void testExecuteSelect() {
+    var client = SpringSupabaseClient.newInstance(baseUrl, "");
+    var query = new SelectQuery.SelectQueryBuilder().select("").from("mocktable").build();
+    var res = client.executeSelect(query, String.class);
+    Assertions.assertEquals("[\"foo\":\"bar\"}]", res);
+  }
 
-    stubFor(
-        WireMock.get(urlEqualTo(""))
-            .willReturn(
-                aResponse()
-                    .withStatus(200)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody("")));
+  @Test
+  void testExecuteInsert() {
+    var client = SpringSupabaseClient.newInstance(baseUrl, "");
+    var query =
+        new InsertQuery.InsertQueryBuilder().insert(Map.of("bar", "baz")).from("mocktable").build();
+    var res = client.executeInsert(query, String.class);
+    Assertions.assertNull(res);
+  }
 
-    var client = SupabaseClient.newInstance("http://localhost:8080", "");
+  @Test
+  void testExecuteDelete() {
+    var client = SpringSupabaseClient.newInstance(baseUrl, "");
+    var query =
+        new DeleteQuery.DeleteQueryBuilder()
+            .delete()
+            .from("mocktable")
+            .filter(new Filter.FilterBuilder().equals("foo", "bar").build())
+            .build();
+    var res = client.executeDelete(query, String.class);
+    Assertions.assertNull(res);
+  }
+
+  @Test
+  void testExecuteUpdate() {
+    var client = SpringSupabaseClient.newInstance(baseUrl, "");
+    var query =
+        new UpdateQuery.UpdateQueryBuilder()
+            .from("mocktable")
+            .update(Map.of("foo", "var"))
+            .filter(new Filter.FilterBuilder().equals("foo", "bar").build())
+            .build();
+    var res = client.executeUpdate(query, String.class);
+    Assertions.assertNull(res);
   }
 }

--- a/supabase-java-spring/src/test/java/com/skhanal5/core/ClientIntegrationTest.java
+++ b/supabase-java-spring/src/test/java/com/skhanal5/core/ClientIntegrationTest.java
@@ -1,23 +1,25 @@
 package com.skhanal5.core;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 @WireMockTest
 public class ClientIntegrationTest {
 
-    @Test
-    void testExecuteSelect() {
+  @Test
+  void testExecuteSelect() {
 
-        stubFor(WireMock.get(urlEqualTo("")).willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody("")));
+    stubFor(
+        WireMock.get(urlEqualTo(""))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("")));
 
-        var client = SupabaseClient.newInstance("http://localhost:8080","");
-
-    }
-
+    var client = SupabaseClient.newInstance("http://localhost:8080", "");
+  }
 }

--- a/supabase-java-spring/src/test/java/com/skhanal5/core/ClientIntegrationTest.java
+++ b/supabase-java-spring/src/test/java/com/skhanal5/core/ClientIntegrationTest.java
@@ -1,0 +1,2 @@
+package com.skhanal5.core;public class ClientIntegrationTest {
+}

--- a/supabase-java-spring/src/test/java/com/skhanal5/core/ClientIntegrationTest.java
+++ b/supabase-java-spring/src/test/java/com/skhanal5/core/ClientIntegrationTest.java
@@ -12,7 +12,7 @@ public class ClientIntegrationTest {
 
   private static MockServer mockServer;
 
-  private static String baseUrl = "http://localhost:8080";
+  private static final String baseUrl = "http://localhost:8080";
 
   @BeforeAll
   public static void setupServer() {

--- a/supabase-java-spring/src/test/java/com/skhanal5/core/ClientIntegrationTest.java
+++ b/supabase-java-spring/src/test/java/com/skhanal5/core/ClientIntegrationTest.java
@@ -2,8 +2,6 @@ package com.skhanal5.core;
 
 import com.skhanal5.core.mockserver.MockServer;
 import com.skhanal5.models.*;
-
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;

--- a/supabase-java-spring/src/test/java/com/skhanal5/core/SpringSupabaseClientTest.java
+++ b/supabase-java-spring/src/test/java/com/skhanal5/core/SpringSupabaseClientTest.java
@@ -1,7 +1,6 @@
 package com.skhanal5.core;
 
 import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.mockito.Mockito.*;
 
 import java.util.List;
 import java.util.Map;
@@ -16,23 +15,23 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-public class SupabaseClientTest {
+public class SpringSupabaseClientTest {
 
   @Test
   void testNewInstanceWithNullDatabaseURL() {
-    Assertions.assertThrows(NullPointerException.class, () -> SupabaseClient.newInstance(null, ""));
+    Assertions.assertThrows(NullPointerException.class, () -> SpringSupabaseClient.newInstance(null, ""));
   }
 
   @Test
   void testNewInstanceWithNullServiceKey() {
-    Assertions.assertThrows(NullPointerException.class, () -> SupabaseClient.newInstance("", null));
+    Assertions.assertThrows(NullPointerException.class, () -> SpringSupabaseClient.newInstance("", null));
   }
 
   @Test
   void testNewInstanceSetsWebClient() {
     var url = "";
     var key = "";
-    var supabaseClient = SupabaseClient.newInstance(url, key);
+    var supabaseClient = SpringSupabaseClient.newInstance(url, key);
     Assertions.assertNotNull(supabaseClient.client);
   }
 
@@ -55,7 +54,7 @@ public class SupabaseClientTest {
   @MethodSource("provideInputAndExpectedResult")
   void testToMultiLevel(
       Optional<Map<String, String>> input, MultiValueMap<String, String> expectedResult) {
-    var client = SupabaseClient.newInstance("", "");
+    var client = SpringSupabaseClient.newInstance("", "");
     var result = client.toMultiValueMap(input);
     Assertions.assertEquals(expectedResult, result);
   }
@@ -64,7 +63,7 @@ public class SupabaseClientTest {
   @MethodSource("provideInputAndExpectedResult")
   void testConstructHttpHeaders(
       Optional<Map<String, String>> input, MultiValueMap<String, String> expectedResult) {
-    var client = SupabaseClient.newInstance("", "");
+    var client = SpringSupabaseClient.newInstance("", "");
     var consumer = client.constructHttpHeaders(input);
     var emptyHeaders = new HttpHeaders(new LinkedMultiValueMap<>());
     consumer.accept(emptyHeaders);

--- a/supabase-java-spring/src/test/java/com/skhanal5/core/SpringSupabaseClientTest.java
+++ b/supabase-java-spring/src/test/java/com/skhanal5/core/SpringSupabaseClientTest.java
@@ -1,7 +1,5 @@
 package com.skhanal5.core;
 
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -14,6 +12,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class SpringSupabaseClientTest {
 

--- a/supabase-java-spring/src/test/java/com/skhanal5/core/SpringSupabaseClientTest.java
+++ b/supabase-java-spring/src/test/java/com/skhanal5/core/SpringSupabaseClientTest.java
@@ -1,5 +1,7 @@
 package com.skhanal5.core;
 
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -13,18 +15,18 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-
 public class SpringSupabaseClientTest {
 
   @Test
   void testNewInstanceWithNullDatabaseURL() {
-    Assertions.assertThrows(NullPointerException.class, () -> SpringSupabaseClient.newInstance(null, ""));
+    Assertions.assertThrows(
+        NullPointerException.class, () -> SpringSupabaseClient.newInstance(null, ""));
   }
 
   @Test
   void testNewInstanceWithNullServiceKey() {
-    Assertions.assertThrows(NullPointerException.class, () -> SpringSupabaseClient.newInstance("", null));
+    Assertions.assertThrows(
+        NullPointerException.class, () -> SpringSupabaseClient.newInstance("", null));
   }
 
   @Test

--- a/supabase-java-spring/src/test/java/com/skhanal5/core/SupabaseClientTest.java
+++ b/supabase-java-spring/src/test/java/com/skhanal5/core/SupabaseClientTest.java
@@ -11,15 +11,24 @@ import org.mockito.Mockito;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClient.RequestHeadersSpec;
+import org.springframework.web.reactive.function.client.WebClient.RequestHeadersUriSpec;
+import reactor.core.publisher.Mono;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 
 public class SupabaseClientTest {
@@ -76,6 +85,4 @@ public class SupabaseClientTest {
     consumer.accept(emptyHeaders);
     Assertions.assertEquals(expectedResult.toSingleValueMap(), emptyHeaders.toSingleValueMap());
   }
-
-
 }

--- a/supabase-java-spring/src/test/java/com/skhanal5/core/SupabaseClientTest.java
+++ b/supabase-java-spring/src/test/java/com/skhanal5/core/SupabaseClientTest.java
@@ -1,25 +1,81 @@
 package com.skhanal5.core;
 
+import com.skhanal5.models.SelectQuery;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+
 
 public class SupabaseClientTest {
 
   @Test
-  void testNewInstanceURLAndServiceKeyMinimal1() {
-    Assertions.assertThrows(NullPointerException.class, () -> SupabaseClient.newInstance("", null));
-  }
-
-  @Test
-  void testNewInstanceURLAndServiceKeyMinimal2() {
+  void testNewInstanceWithNullDatabaseURL() {
     Assertions.assertThrows(NullPointerException.class, () -> SupabaseClient.newInstance(null, ""));
   }
 
   @Test
-  void testNewInstanceURLAndServiceKey() {
+  void testNewInstanceWithNullServiceKey() {
+    Assertions.assertThrows(NullPointerException.class, () -> SupabaseClient.newInstance("", null));
+  }
+
+  @Test
+  void testNewInstanceSetsWebClient() {
     var url = "";
     var key = "";
     var supabaseClient = SupabaseClient.newInstance(url, key);
     Assertions.assertNotNull(supabaseClient.client);
   }
+
+  private static Stream<Arguments> provideInputAndExpectedResult() {
+    var emptyInput = Optional.empty();
+    var emptyMapInput = Optional.of(Map.of());
+    var populatedMapInput = Optional.of(Map.of("foo", "bar"));
+
+
+    var emptyOutput = new LinkedMultiValueMap<String,String>();
+    var populatedMapOutput = new LinkedMultiValueMap<String,String>();
+    populatedMapOutput.put("foo", List.of("bar"));
+
+    return Stream.of(
+            arguments(emptyInput, emptyOutput),
+            arguments(emptyMapInput, emptyOutput),
+            arguments(populatedMapInput, populatedMapOutput)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideInputAndExpectedResult")
+  void testToMultiLevel(Optional<Map<String,String>> input, MultiValueMap<String,String> expectedResult) {
+    var client = SupabaseClient.newInstance("","");
+    var result = client.toMultiValueMap(input);
+    Assertions.assertEquals(expectedResult, result);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideInputAndExpectedResult")
+  void testConstructHttpHeaders(Optional<Map<String,String>> input, MultiValueMap<String,String> expectedResult) {
+    var client = SupabaseClient.newInstance("","");
+    var consumer = client.constructHttpHeaders(input);
+    var emptyHeaders = new HttpHeaders(new LinkedMultiValueMap<>());
+    consumer.accept(emptyHeaders);
+    Assertions.assertEquals(expectedResult.toSingleValueMap(), emptyHeaders.toSingleValueMap());
+  }
+
+
 }

--- a/supabase-java-spring/src/test/java/com/skhanal5/core/SupabaseClientTest.java
+++ b/supabase-java-spring/src/test/java/com/skhanal5/core/SupabaseClientTest.java
@@ -1,35 +1,20 @@
 package com.skhanal5.core;
 
-import com.skhanal5.models.SelectQuery;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mockito;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.reactive.function.client.ClientResponse;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClient.RequestHeadersSpec;
-import org.springframework.web.reactive.function.client.WebClient.RequestHeadersUriSpec;
-import reactor.core.publisher.Mono;
-
-import java.net.URI;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
-
 
 public class SupabaseClientTest {
 
@@ -56,30 +41,30 @@ public class SupabaseClientTest {
     var emptyMapInput = Optional.of(Map.of());
     var populatedMapInput = Optional.of(Map.of("foo", "bar"));
 
-
-    var emptyOutput = new LinkedMultiValueMap<String,String>();
-    var populatedMapOutput = new LinkedMultiValueMap<String,String>();
+    var emptyOutput = new LinkedMultiValueMap<String, String>();
+    var populatedMapOutput = new LinkedMultiValueMap<String, String>();
     populatedMapOutput.put("foo", List.of("bar"));
 
     return Stream.of(
-            arguments(emptyInput, emptyOutput),
-            arguments(emptyMapInput, emptyOutput),
-            arguments(populatedMapInput, populatedMapOutput)
-    );
+        arguments(emptyInput, emptyOutput),
+        arguments(emptyMapInput, emptyOutput),
+        arguments(populatedMapInput, populatedMapOutput));
   }
 
   @ParameterizedTest
   @MethodSource("provideInputAndExpectedResult")
-  void testToMultiLevel(Optional<Map<String,String>> input, MultiValueMap<String,String> expectedResult) {
-    var client = SupabaseClient.newInstance("","");
+  void testToMultiLevel(
+      Optional<Map<String, String>> input, MultiValueMap<String, String> expectedResult) {
+    var client = SupabaseClient.newInstance("", "");
     var result = client.toMultiValueMap(input);
     Assertions.assertEquals(expectedResult, result);
   }
 
   @ParameterizedTest
   @MethodSource("provideInputAndExpectedResult")
-  void testConstructHttpHeaders(Optional<Map<String,String>> input, MultiValueMap<String,String> expectedResult) {
-    var client = SupabaseClient.newInstance("","");
+  void testConstructHttpHeaders(
+      Optional<Map<String, String>> input, MultiValueMap<String, String> expectedResult) {
+    var client = SupabaseClient.newInstance("", "");
     var consumer = client.constructHttpHeaders(input);
     var emptyHeaders = new HttpHeaders(new LinkedMultiValueMap<>());
     consumer.accept(emptyHeaders);

--- a/supabase-java-spring/src/test/java/com/skhanal5/core/mockserver/MockServer.java
+++ b/supabase-java-spring/src/test/java/com/skhanal5/core/mockserver/MockServer.java
@@ -1,0 +1,70 @@
+package com.skhanal5.core.mockserver;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+public class MockServer {
+
+  private WireMockServer mockServer;
+
+  public MockServer() {
+    this.mockServer = new WireMockServer(options().port(8080));
+  }
+
+  public void registerSupabaseStubs() {
+    this.stubSelectTable();
+    this.stubInsertTable();
+    this.stubDeleteTable();
+    this.stubUpdateTable();
+  }
+
+  private void stubSelectTable() {
+    mockServer.stubFor(
+        get(urlPathMatching("/rest/v1/mocktable"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("[\"foo\":\"bar\"}]")));
+  }
+
+  private void stubInsertTable() {
+    mockServer.stubFor(
+        post(urlPathMatching("/rest/v1/mocktable"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("")));
+  }
+
+  private void stubDeleteTable() {
+    mockServer.stubFor(
+        delete(urlPathMatching("/rest/v1/mocktable"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("")));
+  }
+
+  private void stubUpdateTable() {
+    mockServer.stubFor(
+        patch(urlPathMatching("/rest/v1/mocktable"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("")));
+  }
+
+  public void start() {
+    mockServer.start();
+  }
+
+  public void stop() {
+    mockServer.stop();
+  }
+}

--- a/supabase-java-spring/src/test/java/com/skhanal5/core/mockserver/MockServer.java
+++ b/supabase-java-spring/src/test/java/com/skhanal5/core/mockserver/MockServer.java
@@ -7,7 +7,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 
 public class MockServer {
 
-  private WireMockServer mockServer;
+  private final WireMockServer mockServer;
 
   public MockServer() {
     this.mockServer = new WireMockServer(options().port(8080));


### PR DESCRIPTION
This PR does the following:
- Adds wiremock as a dependency to the spring module
- Adds basic unit tests to the Spring client, covering each of operations
- Adds surefire plugin which successfully fixes issue where mvn clean verify wasn't reporting any test results in Github workflow

Another follow-up PR will be opened to make more rigorous tests:
- Remove hard-coded strings from test files and move to resources folder
- Test for specific headers and body values
- Test cases where select() is toggled
- Test unhappy path scenario where we have the wrong base url