### PR TITLE
Bug Fix: Revert workflow changes back to working version

### DIFF
--- a/.github/workflows/release-from-main-workflow.yml
+++ b/.github/workflows/release-from-main-workflow.yml
@@ -15,9 +15,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21
@@ -35,7 +32,7 @@ jobs:
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ github.token }}
 
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
This PR does the following:
- Reverts release-from-main-workflow back to previous working version 